### PR TITLE
Import spawnStateless.

### DIFF
--- a/content/lessons-javascript/getting_started.md
+++ b/content/lessons-javascript/getting_started.md
@@ -30,7 +30,7 @@ Nact has only been tested to work on Node 8 and above. You can install nact in y
 Once installed, you need to import the start function, which starts and then returns the actor system.
 
 ```js
-const { start, dispatch, stop } = require('nact');
+const { start, dispatch, stop, spawnStateless } = require('nact');
 const system = start();
 ```
 


### PR DESCRIPTION
I see from the documentation at [here](https://nact.io/lesson/javascript/getting-started) that it forgot to import spawnStateless in statement:

```javascript
const { start, dispatch, stop } = require('nact');
```

It should be 

```javascript
const { start, dispatch, stop, spawnStateless } = require('nact');
```

This makes the following statement generates error:

```javascript
const greeter = spawnStateless(
  system, // parent
  (msg, ctx) => console.log(`Hello ${msg.name}`), // function
  'greeter' // name
);
```

```
TypeError: system.spawnStateless is not a function
    at Object.<anonymous> (/home/iwan/tmp/learn-nact/index.js:4:24)
    at Module._compile (module.js:635:30)
    at Object.Module._extensions..js (module.js:646:10)
    at Module.load (module.js:554:32)
    at tryModuleLoad (module.js:497:12)
    at Function.Module._load (module.js:489:3)
    at Function.Module.runMain (module.js:676:10)
    at startup (bootstrap_node.js:187:16)
    at bootstrap_node.js:608:3
```