### PR TITLE
fixed links to Erlang and Akka

### DIFF
--- a/content/lessons-reason/introduction.md
+++ b/content/lessons-reason/introduction.md
@@ -12,7 +12,7 @@ tags:
     - reason
     - bucklescript
 ---
-Nact is an implementation of the actor model for Node.js. It is inspired by the approaches taken by [Akka](getakka.net) and [Erlang](https://erlang.com). Additionally it attempts to provide a familiar interface to users coming from Redux. This project provides a wrapper around nact for those using ReasonML and/or Bucklescript.
+Nact is an implementation of the actor model for Node.js. It is inspired by the approaches taken by [Akka](https://getakka.net) and [Erlang](https://www.erlang.org/). Additionally it attempts to provide a familiar interface to users coming from Redux. This project provides a wrapper around nact for those using ReasonML and/or Bucklescript.
 
 The goal of the project is to provide a simple way to create and reason about µ-services and asynchronous event driven architectures in Node.js.
 


### PR DESCRIPTION
I have fixed the links to Erlang and Akka. I believe they point to the correct location now, hope that helps.