### PR TITLE
Tiny doc fix on supervision

### DIFF
--- a/content/lessons-javascript/en_UK/supervision.md
+++ b/content/lessons-javascript/en_UK/supervision.md
@@ -108,5 +108,5 @@ const spawnContactsService = (parent) => spawn(
 );
 ```
 
-The fourth parameter to spawnStateless is the actor property object. 
+The fourth parameter to spawn is the actor property object. 
 This object specifies various other behaviors of actors besides `onCrash` and will be expanded upon in later sections. 


### PR DESCRIPTION
Under supervision, `spawnStateless` was mentioned, were it should read `spawn`.

The Korean version of the docs does not mention `spawnStateless`, so it seems to be fine, but note that my ability to read Korean is non-existent.

